### PR TITLE
Fix/Application path helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   `get_application_path()`, `get_application_name()`, and `get_file_path()` now all require the name of the main package for getting the application's path.
+
+### Fixed
+
+-   Wrong detection of the application path (`__main__` has no attribute)"
+
 ## [0.1.0] - 2023-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,9 +75,13 @@ The package `toolbox.files` offers file related utilities.
 
     ***
 
--   `get_application_name() -> str`:
+-   `get_application_name(name: str) -> str`:
 
     Gets the name of the application, based on the root folder.
+
+    Args:
+
+    -   name (`str`): The main package of the application.
 
     Returns:
 
@@ -85,9 +89,13 @@ The package `toolbox.files` offers file related utilities.
 
     ***
 
--   `get_application_path() -> PurePath`:
+-   `get_application_path(name: str) -> PurePath`:
 
     Gets the path to the application's root.
+
+    Args:
+
+    -   name (`str`): The main package of the application.
 
     Returns:
 
@@ -95,13 +103,14 @@ The package `toolbox.files` offers file related utilities.
 
     ***
 
--   `get_file_path(relative) -> PurePath`:
+-   `get_file_path(relative: str, name: str) -> PurePath`:
 
     Gets a full path for a file inside the application.
 
     Args:
 
     -   relative (`str`): The internal path the file from the application's root.
+    -   name (`str`): The main package of the application.
 
     Returns:
 

--- a/toolbox/files/path.py
+++ b/toolbox/files/path.py
@@ -30,42 +30,52 @@ def get_module_folder_path(name: str) -> PurePath():
         - name (str): The module for which get the path.
 
     Returns:
-        PurePath|None: The path to the folder containing the given module.
+        PurePath: The path to the folder containing the given module.
     """
-    return get_module_path(name).parent
+    if name in sys.modules:
+        return PurePath(sys.modules[name].__path__)
+
+    return PurePath()
 
 
-def get_application_path() -> PurePath:
+def get_application_path(name: str) -> PurePath:
     """
     Gets the path to the application's root.
+
+    Args:
+        - name (str): The main package of the application.
 
     Returns:
         PurePath: The path to the application's root.
     """
-    return get_module_folder_path("__main__")
+    return get_module_folder_path(name).parent
 
 
-def get_application_name() -> str:
+def get_application_name(name: str) -> str:
     """
     Gets the name of the application, based on the root folder.
+
+    Args:
+        - name (str): The main package of the application.
 
     Returns:
         - str: The name of the application.
     """
-    return get_application_path().name
+    return get_application_path(name).name
 
 
-def get_file_path(relative) -> PurePath:
+def get_file_path(relative: str, name: str) -> PurePath:
     """
     Gets a full path for a file inside the application.
 
     Args:
         - relative (str): The internal path the file from the application's root.
+        - name (str): The main package of the application.
 
     Returns:
         PurePath: The full path.
     """
-    return get_application_path().joinpath(relative)
+    return get_application_path(name).joinpath(relative)
 
 
 def create_file_path(path: str) -> bool:

--- a/toolbox/files/test/test_path.py
+++ b/toolbox/files/test/test_path.py
@@ -20,14 +20,20 @@ class TestFilePaths(unittest.TestCase):
         """
         mock_namespace = "app.package.module"
         mock_path = "/root/app/package/module.py"
+        mock_folder = "/root/app/package"
 
         module_mock = Mock()
         module_mock.__file__ = mock_path
+        module_mock.__path__ = mock_folder
 
         with patch.dict(sys.modules, {mock_namespace: module_mock}):
             result = path.get_module_path(mock_namespace)
             self.assertIsInstance(result, PurePath)
             self.assertEqual(str(result), mock_path)
+
+        result = path.get_module_path("foo")
+        self.assertIsInstance(result, PurePath)
+        self.assertEqual(str(result), ".")
 
     def test_get_module_folder(self):
         """
@@ -39,60 +45,82 @@ class TestFilePaths(unittest.TestCase):
 
         module_mock = Mock()
         module_mock.__file__ = mock_path
+        module_mock.__path__ = mock_folder
 
         with patch.dict(sys.modules, {mock_namespace: module_mock}):
             result = path.get_module_folder_path(mock_namespace)
             self.assertIsInstance(result, PurePath)
             self.assertEqual(str(result), mock_folder)
 
+        result = path.get_module_folder_path("foo")
+        self.assertIsInstance(result, PurePath)
+        self.assertEqual(str(result), ".")
+
     def test_get_application_path(self):
         """
         Tests the helper get_application_path().
         """
-        mock_namespace = "__main__"
-        mock_path = "/root/app/main.py"
+        mock_namespace = "app"
+        mock_path = "/root/app/package/module.py"
+        mock_folder = "/root/app/package"
         mock_root = "/root/app"
 
         module_mock = Mock()
         module_mock.__file__ = mock_path
+        module_mock.__path__ = mock_folder
 
         with patch.dict(sys.modules, {mock_namespace: module_mock}):
-            result = path.get_application_path()
+            result = path.get_application_path(mock_namespace)
             self.assertIsInstance(result, PurePath)
             self.assertEqual(str(result), mock_root)
+
+        result = path.get_application_path("foo")
+        self.assertIsInstance(result, PurePath)
+        self.assertEqual(str(result), ".")
 
     def test_get_application_name(self):
         """
         Tests the helper get_application_name().
         """
-        mock_namespace = "__main__"
-        mock_path = "/root/app/main.py"
+        mock_namespace = "app"
+        mock_path = "/root/app/package/module.py"
+        mock_folder = "/root/app/package"
         mock_name = "app"
 
         module_mock = Mock()
         module_mock.__file__ = mock_path
+        module_mock.__path__ = mock_folder
 
         with patch.dict(sys.modules, {mock_namespace: module_mock}):
-            result = path.get_application_name()
+            result = path.get_application_name(mock_namespace)
             self.assertIsInstance(result, str)
             self.assertEqual(result, mock_name)
+
+        result = path.get_application_name("foo")
+        self.assertEqual(result, "")
 
     def test_get_file_path(self):
         """
         Tests the helper get_file_path().
         """
-        mock_namespace = "__main__"
-        mock_path = "/root/app/main.py"
+        mock_namespace = "app"
+        mock_path = "/root/app/package/module.py"
+        mock_folder = "/root/app/package"
         mock_root = "/root/app"
-        test_param = "subfolder/file"
+        file_path = "subfolder/file"
 
         module_mock = Mock()
         module_mock.__file__ = mock_path
+        module_mock.__path__ = mock_folder
 
         with patch.dict(sys.modules, {mock_namespace: module_mock}):
-            result = path.get_file_path(test_param)
+            result = path.get_file_path(file_path, mock_namespace)
             self.assertIsInstance(result, PurePath)
-            self.assertEqual(str(result), f"{mock_root}/{test_param}")
+            self.assertEqual(str(result), f"{mock_root}/{file_path}")
+
+        result = path.get_file_path(file_path, "foo")
+        self.assertIsInstance(result, PurePath)
+        self.assertEqual(str(result), file_path)
 
     def test_create_file_path(self):
         """


### PR DESCRIPTION
Fix a trivial issue with the helper `get_application_path()`. The method used was not working, the `__main__` module has no attribute.

To get the application's path, we now need to give the name of the main package.