### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Wrong use of the module path
+
 ## [0.1.1] - 2023-09-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2023-09-05
+
 ### Fixed
 
 -   Wrong use of the module path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py-toolbox"
-version = "0.1.1"
+version = "0.1.2"
 authors = [{ name = "Jean-Sébastien CONAN", email = "jsconan@gmail.com" }]
 description = "A set of utilities for Python projects"
 readme = "README.md"

--- a/toolbox/files/path.py
+++ b/toolbox/files/path.py
@@ -32,10 +32,7 @@ def get_module_folder_path(name: str) -> PurePath():
     Returns:
         PurePath: The path to the folder containing the given module.
     """
-    if name in sys.modules:
-        return PurePath(sys.modules[name].__path__)
-
-    return PurePath()
+    return get_module_path(name).parent
 
 
 def get_application_path(name: str) -> PurePath:


### PR DESCRIPTION
Wrong use of the module path.

It was generating the error `TypeError: expected str, bytes or os.PathLike object, not list`