### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Increase coverage
+
+### Fixed
+
+-   Wrong use of `fieldnames=False` in `CSVFile.write()`.
+
 ## [0.5.0] - 2023-09-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2023-09-13
+
 ### Changed
 
 -   Increase coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "py-toolbox"
-version = "0.5.0"
+version = "0.5.1"
 authors = [{ name = "Jean-Sébastien CONAN", email = "jsconan@gmail.com" }]
 description = "A set of utilities for Python projects"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 astroid==2.15.6
 click==8.1.7
+coverage==7.3.1
 dill==0.3.7
 isort==5.12.0
 lazy-object-proxy==1.9.0

--- a/toolbox/config/test/test_config.py
+++ b/toolbox/config/test/test_config.py
@@ -154,6 +154,7 @@ class TestConfig(unittest.TestCase):
 
         self.assertEqual(config.describe("a"), "foo")
         self.assertEqual(config.describe("b"), "")
+        self.assertEqual(config.describe("c"), "")
 
     def test_choices(self):
         """Test the choices of an option can be retrieved."""
@@ -343,6 +344,11 @@ class TestConfig(unittest.TestCase):
         del config["a"]
         self.assertNotIn("a", config)
         self.assertRaises(IndexError, lambda: config["a"])
+
+        def delete(key):
+            del config[key]
+
+        self.assertRaises(IndexError, lambda: delete("a"))
 
     def test_direct_access(self):
         """Test the access to a configuration option."""

--- a/toolbox/config/test/test_config_option.py
+++ b/toolbox/config/test/test_config_option.py
@@ -98,6 +98,8 @@ class TestConfigOption(unittest.TestCase):
 
     def test_create_option_fail(self):
         """Test the creation of an option raises an error."""
+        self.assertRaises(ValueError, lambda: ConfigOption(""))
+        self.assertRaises(ValueError, lambda: ConfigOption("foo", mapper=True))
         self.assertRaises(ValueError, lambda: ConfigOption("foo", choices=["bar"]))
         self.assertRaises(
             ValueError, lambda: ConfigOption("foo", value="baz", choices=["bar"])
@@ -418,6 +420,7 @@ class TestConfigOption(unittest.TestCase):
         self.assertEqual(foo10, foo10.copy())
         self.assertNotEqual(foo10, foo20)
         self.assertNotEqual(foo10, bar10)
+        self.assertNotEqual(foo10, "foo10")
 
 
 class TestCreateOptions(unittest.TestCase):

--- a/toolbox/data/mappers.py
+++ b/toolbox/data/mappers.py
@@ -33,7 +33,7 @@ class ValueMapper(Protocol):
     """
 
     def __call__(self, value: Any) -> Any:
-        return value
+        return value  # pragma: no cover
 
 
 def passthrough(value: Any) -> Any:

--- a/toolbox/files/csv_file.py
+++ b/toolbox/files/csv_file.py
@@ -433,15 +433,14 @@ class CSVFile(FileManager):
             if isinstance(data, dict):
                 header = True
 
-                if kwargs.get("fieldnames") is False:
-                    kwargs.pop("fieldnames")
-                    header = False
-
-                elif "fieldnames" not in kwargs:
+                if "fieldnames" not in kwargs or kwargs.get("fieldnames") is False:
                     kwargs["fieldnames"] = data.keys()
 
                 writer = csv.DictWriter
             else:
+                if "fieldnames" in kwargs:
+                    kwargs.pop("fieldnames")
+
                 header = False
                 writer = csv.writer
 

--- a/toolbox/files/test/test_csv_file.py
+++ b/toolbox/files/test/test_csv_file.py
@@ -252,12 +252,24 @@ class TestCSVFile(unittest.TestCase):
         [
             ["dictionaries", {}, CSV_LINES_DICT, CSV_STRING],
             [
+                "dictionaries with fieldnames=False",
+                {"fieldnames": False},
+                CSV_LINES_DICT,
+                CSV_STRING,
+            ],
+            [
                 "fieldnames",
                 {"fieldnames": ["first_name", "last_name"], "extrasaction": "ignore"},
                 CSV_LINES_DICT,
                 "".join(CSV_LINES_REDUCED),
             ],
             ["list", {}, CSV_LINES_LIST[1:], "".join(CSV_LINES_STRING[1:])],
+            [
+                "list with fieldnames=False",
+                {"fieldnames": False},
+                CSV_LINES_LIST[1:],
+                "".join(CSV_LINES_STRING[1:]),
+            ],
             ["auto", {"dialect": "auto"}, CSV_LINES_DICT, CSV_STRING],
         ]
     )

--- a/toolbox/logging/config.py
+++ b/toolbox/logging/config.py
@@ -33,7 +33,7 @@ def setup_file_logging(
     encoding: str = LOG_ENCODING,
     log_format: str = LOG_FORMAT,
     **kwargs,
-) -> None:
+) -> None:  # pragma: no cover
     """Setup the application log to a file logger.
 
     By default, a file will be created in the current working directory, named 'app.log'.
@@ -60,7 +60,7 @@ def setup_file_logging(
     )
 
 
-def handle_uncaught_exceptions() -> None:
+def handle_uncaught_exceptions() -> None:  # pragma: no cover
     """Installs a collector for logging uncaught exceptions.
 
     When an exception is not handled in the code, it will be logged with the message:

--- a/toolbox/testing/test/test_test_case.py
+++ b/toolbox/testing/test/test_test_case.py
@@ -114,7 +114,7 @@ class TestAsserts(TestCase):
         except AssertionError:
             pass
         else:
-            raise AssertionError("lists are not almost equal")
+            raise AssertionError("lists are not almost equal")  # pragma: no cover
 
     @test_cases(
         [
@@ -201,4 +201,4 @@ class TestAsserts(TestCase):
         except AssertionError:
             pass
         else:
-            raise AssertionError("lists are not almost equal")
+            raise AssertionError("lists are not almost equal")  # pragma: no cover


### PR DESCRIPTION
### Changed

-   Increase coverage

### Fixed

-   Wrong use of `fieldnames=False` in `CSVFile.write()`.