### PR TITLE
Feature/Optimize combination helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   `get_combination_index(combination, max_value)`: Gets the index of a combination.
--   `get_combination_from_index(index, length, max_value)`: Gets the combination corresponding to a particular index.
+-   `get_combination_rank(combination, offset)`: Gets the rank of a combination.
+-   `get_combination_from_rank(rank, length, offset)`: Gets the combination corresponding to a particular rank.
 -   `get_cache_path(name, create)` - Gets the path to a cache folder.
 -   `ValueExtractor(entries, mapper)` - A tool for extracting values from a set of possible entries.
 -   `decimal(separator, thousands)` - Creates a mapper for casting decimal values to floats.

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,8 +71,8 @@
 - [`pickle_file.write_pickle_file`](./toolbox.files.pickle_file.md#function-write_pickle_file): Writes a list of objects to a file.
 - [`config.handle_uncaught_exceptions`](./toolbox.logging.config.md#function-handle_uncaught_exceptions): Installs a collector for logging uncaught exceptions.
 - [`config.setup_file_logging`](./toolbox.logging.config.md#function-setup_file_logging): Setup the application log to a file logger.
-- [`combination.get_combination_from_index`](./toolbox.math.combination.md#function-get_combination_from_index): Gets the combination corresponding to a particular index.
-- [`combination.get_combination_index`](./toolbox.math.combination.md#function-get_combination_index): Gets the index of a combination.
+- [`combination.get_combination_from_rank`](./toolbox.math.combination.md#function-get_combination_from_rank): Gets the combination corresponding to a particular rank.
+- [`combination.get_combination_rank`](./toolbox.math.combination.md#function-get_combination_rank): Gets the rank of a combination.
 - [`decorators.test_cases`](./toolbox.testing.decorators.md#function-test_cases): Creates a decorator for parametric test cases.
 
 

--- a/docs/toolbox.math.combination.md
+++ b/docs/toolbox.math.combination.md
@@ -12,7 +12,7 @@ A set of functions for working with combinations.
 from toolbox.math import get_combination_rank, get_combination_from_rank
 
 # Get the rank of a combination of 3 numbers
-print(get_combination_rank([1,3,5]))
+print(get_combination_rank([1, 3, 5]))
 
 # Get the combination of 3 numbers ranked at position 5
 print(list(get_combination_from_rank(5, 3)))
@@ -46,7 +46,7 @@ The rank starts at 0. The values in the combination must start at 0. Negative nu
 
 **Raises:**
  
- - <b>`ValueError`</b>:  If the combination contains values lower than 0. 
+ - <b>`ValueError`</b>:  If the combination contains negative values. 
 
 
 
@@ -61,7 +61,7 @@ The rank starts at 0. The values in the combination must start at 0. Negative nu
 from toolbox.math import get_combination_rank
 
 # Get the rank of a combination of 3 numbers
-print(get_combination_rank([1,3,5]))
+print(get_combination_rank([1, 3, 5]))
 ``` 
 
 

--- a/docs/toolbox.math.combination.md
+++ b/docs/toolbox.math.combination.md
@@ -9,13 +9,13 @@ A set of functions for working with combinations.
 
 **Examples:**
  ```python
-from toolbox.math import get_combination_index, get_combination_from_index
+from toolbox.math import get_combination_rank, get_combination_from_rank
 
-# Get the index of a combination
-print(get_combination_index([1,3,5], 8))
+# Get the rank of a combination of 3 numbers
+print(get_combination_rank([1,3,5]))
 
-# Get the combination from an index
-print(list(get_combination_from_index(5, 8)))
+# Get the combination of 3 numbers ranked at position 5
+print(list(get_combination_from_rank(5, 3)))
 ``` 
 
 
@@ -23,104 +23,95 @@ print(list(get_combination_from_index(5, 8)))
 
 <a href="../src/toolbox/math/combination.py#L18"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-## <kbd>function</kbd> `get_combination_index`
+## <kbd>function</kbd> `get_combination_rank`
 
 ```python
-get_combination_index(combination: Iterable[int], max_value: int = 52) → int
+get_combination_rank(combination: Iterable[int], offset: int = 0) → int
 ```
 
-Gets the index of a combination. 
+Gets the rank of a combination. 
 
-The values in the combination must be in the range 1..max_value included. 
+The combination is sorted before computing the rank. 
 
-The first index is 1. The last index if equal to `comb(12, len(combination))` 
-
-The combination is sorted before computing the index. 
+The rank starts at 0. The values in the combination must start at 0. Negative numbers will raise an error. 
 
 
 
 **Args:**
  
- - <b>`combination`</b> (Iterable[int]):  The combination to index. 
- - <b>`max_value`</b> (int, optional):  The maximum value for the combination. Defaults to 52. 
+ - <b>`combination`</b> (Iterable[int]):  The combination to rank. 
+ - <b>`offset`</b> (int, optional):  An offset to remove from the values if they don't start at 0. Defaults to 0. 
 
 
 
 **Raises:**
  
- - <b>`ValueError`</b>:  If the max_value is lower than 1. 
- - <b>`ValueError`</b>:  If the combination is empty. 
- - <b>`ValueError`</b>:  If the combination contains values lower than 1. 
+ - <b>`ValueError`</b>:  If the combination contains values lower than 0. 
 
 
 
 **Returns:**
  
- - <b>`int`</b>:  The index of the combination. 
+ - <b>`int`</b>:  The rank of the combination, starting at 0. 
 
 
 
 **Examples:**
  ```python
-from toolbox.math import get_combination_index
+from toolbox.math import get_combination_rank
 
-# Get the index of a combination for 3 numbers out of 8
-print(get_combination_index([1,3,5], 8))
+# Get the rank of a combination of 3 numbers
+print(get_combination_rank([1,3,5]))
 ``` 
 
 
 ---
 
-<a href="../src/toolbox/math/combination.py#L67"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/toolbox/math/combination.py#L57"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
-## <kbd>function</kbd> `get_combination_from_index`
+## <kbd>function</kbd> `get_combination_from_rank`
 
 ```python
-get_combination_from_index(
-    index: int,
+get_combination_from_rank(
+    rank: int,
     length: int = 2,
-    max_value: int = 52
-) → Iterator[int]
+    offset: int = 0
+) → list[int]
 ```
 
-Gets the combination corresponding to a particular index. 
+Gets the combination corresponding to a particular rank. 
 
-The values in the combination will be in the range 1..max_value included. 
-
-The index must be in the range 1..comb(12, len(combination)) included. 
+The rank must start at 0. 
 
 
 
 **Args:**
  
- - <b>`index`</b> (int):  The index of the combination. 
+ - <b>`rank`</b> (int):  The rank of the combination. 
  - <b>`length`</b> (int, optional):  The length of the combination. Defaults to 2. 
- - <b>`max_value`</b> (int, optional):  The maximum value for the combination. Defaults to 52. 
+ - <b>`offset`</b> (int, optional):  An offset to add to the values if they must not start at 0. Defaults to 0. 
 
 
 
 **Raises:**
  
- - <b>`ValueError`</b>:  If the length is lower than 1. 
- - <b>`ValueError`</b>:  If the max_value is lower than 1. 
- - <b>`ValueError`</b>:  If the index is lower than 1 or greater than the number of combinations. 
+ - <b>`ValueError`</b>:  If the rank is negative. 
+ - <b>`ValueError`</b>:  If the length is negative 
 
 
 
-
-
-**Yields:**
+**Returns:**
  
- - <b>`Iterator[int]`</b>:  A number from the combination corresponding to the index. 
+ - <b>`list[int]`</b>:  The combination corresponding to the rank, sorted by ascending values. 
 
 
 
 **Examples:**
  ```python
-from toolbox.math import get_combination_from_index
+from toolbox.math import get_combination_from_rank
 
-# Get the combination for 3 numbers out of 8 from an index
-print(list(get_combination_from_index(5, 3, 8)))
+# Get the combination of 3 numbers ranked at position 5
+print(list(get_combination_from_rank(5, 3)))
 ``` 
 
 

--- a/docs/toolbox.math.md
+++ b/docs/toolbox.math.md
@@ -6,20 +6,20 @@
 A collection of Math related tools. 
 
 It contains: 
-- `get_combination_index(combination, max_value)`: Gets the index of a combination. 
-- `get_combination_from_index(index, length, max_value)`: Gets the combination corresponding to a particular index. 
+- `get_combination_rank(combination, offset)`: Gets the rank of a combination. 
+- `get_combination_from_rank(rank, length, offset)`: Gets the combination corresponding to a particular rank. 
 
 
 
 **Examples:**
  ```python
-from toolbox.math import get_combination_index, get_combination_from_index
+from toolbox.math import get_combination_rank, get_combination_from_rank
 
-# Get the index of a combination
-print(get_combination_index([1,3,5], 8))
+# Get the rank of a combination of 3 numbers
+print(get_combination_rank([1,3,5]))
 
-# Get the combination from an index
-print(list(get_combination_from_index(5, 8)))
+# Get the combination of 3 numbers ranked at position 5
+print(list(get_combination_from_rank(5, 3)))
 ``` 
 
 **Global Variables**

--- a/docs/toolbox.math.md
+++ b/docs/toolbox.math.md
@@ -16,7 +16,7 @@ It contains:
 from toolbox.math import get_combination_rank, get_combination_from_rank
 
 # Get the rank of a combination of 3 numbers
-print(get_combination_rank([1,3,5]))
+print(get_combination_rank([1, 3, 5]))
 
 # Get the combination of 3 numbers ranked at position 5
 print(list(get_combination_from_rank(5, 3)))

--- a/src/toolbox/math/__init__.py
+++ b/src/toolbox/math/__init__.py
@@ -10,7 +10,7 @@ Examples:
 from toolbox.math import get_combination_rank, get_combination_from_rank
 
 # Get the rank of a combination of 3 numbers
-print(get_combination_rank([1,3,5]))
+print(get_combination_rank([1, 3, 5]))
 
 # Get the combination of 3 numbers ranked at position 5
 print(list(get_combination_from_rank(5, 3)))

--- a/src/toolbox/math/__init__.py
+++ b/src/toolbox/math/__init__.py
@@ -1,19 +1,19 @@
 """A collection of Math related tools.
 
 It contains:
-- `get_combination_rank(combination, max_value)`: Gets the rank of a combination.
-- `get_combination_from_rank(rank, length, max_value)`: Gets the combination corresponding to a
+- `get_combination_rank(combination, offset)`: Gets the rank of a combination.
+- `get_combination_from_rank(rank, length, offset)`: Gets the combination corresponding to a
 particular rank.
 
 Examples:
 ```python
 from toolbox.math import get_combination_rank, get_combination_from_rank
 
-# Get the rank of a combination
-print(get_combination_rank([1,3,5], 8))
+# Get the rank of a combination of 3 numbers
+print(get_combination_rank([1,3,5]))
 
-# Get the combination from an rank
-print(list(get_combination_from_rank(5, 8)))
+# Get the combination of 3 numbers ranked at position 5
+print(list(get_combination_from_rank(5, 3)))
 ```
 """
 from toolbox.math.combination import get_combination_from_rank, get_combination_rank

--- a/src/toolbox/math/__init__.py
+++ b/src/toolbox/math/__init__.py
@@ -1,19 +1,19 @@
 """A collection of Math related tools.
 
 It contains:
-- `get_combination_index(combination, max_value)`: Gets the index of a combination.
-- `get_combination_from_index(index, length, max_value)`: Gets the combination corresponding to a
-particular index.
+- `get_combination_rank(combination, max_value)`: Gets the rank of a combination.
+- `get_combination_from_rank(rank, length, max_value)`: Gets the combination corresponding to a
+particular rank.
 
 Examples:
 ```python
-from toolbox.math import get_combination_index, get_combination_from_index
+from toolbox.math import get_combination_rank, get_combination_from_rank
 
-# Get the index of a combination
-print(get_combination_index([1,3,5], 8))
+# Get the rank of a combination
+print(get_combination_rank([1,3,5], 8))
 
-# Get the combination from an index
-print(list(get_combination_from_index(5, 8)))
+# Get the combination from an rank
+print(list(get_combination_from_rank(5, 8)))
 ```
 """
-from toolbox.math.combination import get_combination_from_index, get_combination_index
+from toolbox.math.combination import get_combination_from_rank, get_combination_rank

--- a/src/toolbox/math/combination.py
+++ b/src/toolbox/math/combination.py
@@ -5,7 +5,7 @@ Examples:
 from toolbox.math import get_combination_rank, get_combination_from_rank
 
 # Get the rank of a combination of 3 numbers
-print(get_combination_rank([1,3,5]))
+print(get_combination_rank([1, 3, 5]))
 
 # Get the combination of 3 numbers ranked at position 5
 print(list(get_combination_from_rank(5, 3)))
@@ -29,7 +29,7 @@ def get_combination_rank(combination: Iterable[int], offset: int = 0) -> int:
         Defaults to 0.
 
     Raises:
-        ValueError: If the combination contains values lower than 0.
+        ValueError: If the combination contains negative values.
 
     Returns:
         int: The rank of the combination, starting at 0.
@@ -39,7 +39,7 @@ def get_combination_rank(combination: Iterable[int], offset: int = 0) -> int:
     from toolbox.math import get_combination_rank
 
     # Get the rank of a combination of 3 numbers
-    print(get_combination_rank([1,3,5]))
+    print(get_combination_rank([1, 3, 5]))
     ```
     """
     rank = 0

--- a/src/toolbox/math/combination.py
+++ b/src/toolbox/math/combination.py
@@ -2,31 +2,31 @@
 
 Examples:
 ```python
-from toolbox.math import get_combination_index, get_combination_from_index
+from toolbox.math import get_combination_rank, get_combination_from_rank
 
-# Get the index of a combination
-print(get_combination_index([1,3,5], 8))
+# Get the rank of a combination
+print(get_combination_rank([1,3,5], 8))
 
-# Get the combination from an index
-print(list(get_combination_from_index(5, 8)))
+# Get the combination from a rank
+print(list(get_combination_from_rank(5, 8)))
 ```
 """
 from math import comb
 from typing import Iterable, Iterator
 
 
-def get_combination_index(combination: Iterable[int], max_value: int = 52) -> int:
-    """Gets the index of a combination.
+def get_combination_rank(combination: Iterable[int], max_value: int = 52) -> int:
+    """Gets the rank of a combination.
 
     The values in the combination must be in the range 1..max_value included.
 
-    The first index is 1.
-    The last index if equal to `comb(12, len(combination))`
+    The first rank is 1.
+    The last rank if equal to `comb(12, len(combination))`
 
-    The combination is sorted before computing the index.
+    The combination is sorted before computing the rank.
 
     Args:
-        combination (Iterable[int]): The combination to index.
+        combination (Iterable[int]): The combination to rank.
         max_value (int, optional): The maximum value for the combination. Defaults to 52.
 
     Raises:
@@ -35,14 +35,14 @@ def get_combination_index(combination: Iterable[int], max_value: int = 52) -> in
         ValueError: If the combination contains values lower than 1.
 
     Returns:
-        int: The index of the combination.
+        int: The rank of the combination.
 
     Examples:
     ```python
-    from toolbox.math import get_combination_index
+    from toolbox.math import get_combination_rank
 
-    # Get the index of a combination for 3 numbers out of 8
-    print(get_combination_index([1,3,5], 8))
+    # Get the rank of a combination for 3 numbers out of 8
+    print(get_combination_rank([1,3,5], 8))
     ```
     """
     combination = sorted(combination)
@@ -54,47 +54,46 @@ def get_combination_index(combination: Iterable[int], max_value: int = 52) -> in
     if not length:
         raise ValueError("The combination must contain values")
 
-    index = comb(max_value, length)
+    rank = comb(max_value, length)
     for idx in range(length):
         value = combination[idx]
         if value < 1:
             raise ValueError("The combination must not contain values lower than 1")
-        index -= comb(max_value - value, length - idx)
+        rank -= comb(max_value - value, length - idx)
 
-    return index
+    return rank
 
 
-def get_combination_from_index(
-    index: int,
+def get_combination_from_rank(
+    rank: int,
     length: int = 2,
     max_value: int = 52,
 ) -> Iterator[int]:
-    """Gets the combination corresponding to a particular index.
+    """Gets the combination corresponding to a particular rank.
 
     The values in the combination will be in the range 1..max_value included.
 
-    The index must be in the range 1..comb(12, len(combination)) included.
+    The rank must be in the range 1..comb(12, len(combination)) included.
 
     Args:
-        index (int): The index of the combination.
+        rank (int): The rank of the combination.
         length (int, optional): The length of the combination. Defaults to 2.
         max_value (int, optional): The maximum value for the combination. Defaults to 52.
 
     Raises:
         ValueError: If the length is lower than 1.
         ValueError: If the max_value is lower than 1.
-        ValueError: If the index is lower than 1 or greater than the number of combinations.
-
+        ValueError: If the rank is lower than 1 or greater than the number of combinations.
 
     Yields:
-        Iterator[int]: A number from the combination corresponding to the index.
+        Iterator[int]: A number from the combination corresponding to the rank.
 
     Examples:
     ```python
-    from toolbox.math import get_combination_from_index
+    from toolbox.math import get_combination_from_rank
 
-    # Get the combination for 3 numbers out of 8 from an index
-    print(list(get_combination_from_index(5, 3, 8)))
+    # Get the combination for 3 numbers out of 8 from a rank
+    print(list(get_combination_from_rank(5, 3, 8)))
     ```
     """
     if length < 1:
@@ -103,15 +102,15 @@ def get_combination_from_index(
     if max_value < 1:
         raise ValueError("The max value must not be lower than 1")
 
-    max_index = comb(max_value, length)
+    max_rank = comb(max_value, length)
 
-    if index < 1:
-        raise ValueError("The index must not be lower than 1")
+    if rank < 1:
+        raise ValueError("The rank must not be lower than 1")
 
-    if index > max_index:
-        raise ValueError("The index must not be greater than the number of possible combinations")
+    if rank > max_rank:
+        raise ValueError("The rank must not be greater than the number of possible combinations")
 
-    idx = max_index - index
+    idx = max_rank - rank
     for pos in range(length, 0, -1):
         val_idx = 0
         value = 0

--- a/src/toolbox/math/combination.py
+++ b/src/toolbox/math/combination.py
@@ -4,138 +4,114 @@ Examples:
 ```python
 from toolbox.math import get_combination_rank, get_combination_from_rank
 
-# Get the rank of a combination
-print(get_combination_rank([1,3,5], 8))
+# Get the rank of a combination of 3 numbers
+print(get_combination_rank([1,3,5]))
 
-# Get the combination from a rank
-print(list(get_combination_from_rank(5, 8)))
+# Get the combination of 3 numbers ranked at position 5
+print(list(get_combination_from_rank(5, 3)))
 ```
 """
 from math import comb
-from typing import Iterable, Iterator
+from typing import Iterable
 
 
-def get_combination_rank(combination: Iterable[int], max_value: int = 52) -> int:
+def get_combination_rank(combination: Iterable[int], offset: int = 0) -> int:
     """Gets the rank of a combination.
-
-    The values in the combination must be in the range 1..max_value included.
-
-    The first rank is 1.
-    The last rank if equal to `comb(12, len(combination))`
 
     The combination is sorted before computing the rank.
 
+    The rank starts at 0.
+    The values in the combination must start at 0. Negative numbers will raise an error.
+
     Args:
         combination (Iterable[int]): The combination to rank.
-        max_value (int, optional): The maximum value for the combination. Defaults to 52.
+        offset (int, optional): An offset to remove from the values if they don't start at 0.
+        Defaults to 0.
 
     Raises:
-        ValueError: If the max_value is lower than 1.
-        ValueError: If the combination is empty.
-        ValueError: If the combination contains values lower than 1.
+        ValueError: If the combination contains values lower than 0.
 
     Returns:
-        int: The rank of the combination.
+        int: The rank of the combination, starting at 0.
 
     Examples:
     ```python
     from toolbox.math import get_combination_rank
 
-    # Get the rank of a combination for 3 numbers out of 8
-    print(get_combination_rank([1,3,5], 8))
+    # Get the rank of a combination of 3 numbers
+    print(get_combination_rank([1,3,5]))
     ```
     """
-    combination = sorted(combination)
-    length = len(combination)
+    rank = 0
+    for index, value in enumerate(sorted(combination)):
+        value -= offset
 
-    if max_value < 1:
-        raise ValueError("The max value must not be lower than 1")
+        if value == index:
+            continue
 
-    if not length:
-        raise ValueError("The combination must contain values")
-
-    if length > max_value:
-        raise ValueError("The combination cannot have move values than the max value")
-
-    if length == 1:
-        return combination[0]
-
-    if length == max_value:
-        return 1
-
-    rank = comb(max_value, length)
-    for index, value in enumerate(combination):
-        if value < 1:
-            raise ValueError("The combination must not contain values lower than 1")
-        rank -= comb(max_value - value, length - index)
+        rank += comb(value, index + 1)
 
     return rank
 
 
-def get_combination_from_rank(
-    rank: int,
-    length: int = 2,
-    max_value: int = 52,
-) -> Iterator[int]:
+def get_combination_from_rank(rank: int, length: int = 2, offset: int = 0) -> list[int]:
     """Gets the combination corresponding to a particular rank.
 
-    The values in the combination will be in the range 1..max_value included.
-
-    The rank must be in the range 1..comb(12, len(combination)) included.
+    The rank must start at 0.
 
     Args:
         rank (int): The rank of the combination.
         length (int, optional): The length of the combination. Defaults to 2.
-        max_value (int, optional): The maximum value for the combination. Defaults to 52.
+        offset (int, optional): An offset to add to the values if they must not start at 0.
+        Defaults to 0.
 
     Raises:
-        ValueError: If the length is lower than 1.
-        ValueError: If the max_value is lower than 1.
-        ValueError: If the rank is lower than 1 or greater than the number of combinations.
+        ValueError: If the rank is negative.
+        ValueError: If the length is negative
 
-    Yields:
-        Iterator[int]: A number from the combination corresponding to the rank.
+    Returns:
+        list[int]: The combination corresponding to the rank, sorted by ascending values.
 
     Examples:
     ```python
     from toolbox.math import get_combination_from_rank
 
-    # Get the combination for 3 numbers out of 8 from a rank
-    print(list(get_combination_from_rank(5, 3, 8)))
+    # Get the combination of 3 numbers ranked at position 5
+    print(list(get_combination_from_rank(5, 3)))
     ```
     """
-    if length < 1:
-        raise ValueError("The combination length must not be lower than 1")
+    if rank < 0:
+        raise ValueError("The rank must not be negative")
 
-    if max_value < 1:
-        raise ValueError("The max value must not be lower than 1")
+    if length < 0:
+        raise ValueError("The length must not be negative")
 
-    max_rank = comb(max_value, length)
-
-    if rank < 1:
-        raise ValueError("The rank must not be lower than 1")
-
-    if rank > max_rank:
-        raise ValueError("The rank must not be greater than the number of possible combinations")
+    if length == 0:
+        return []
 
     if length == 1:
-        yield rank
-        return
+        return [rank + offset]
 
-    if length == max_value:
-        for value in range(1, length + 1):
-            yield value
-        return
+    combination = [0] * length
 
-    idx = max_rank - rank
+    binomial = 0
+    val = 0
+    b = 1
+    while b <= rank:
+        val += 1
+        binomial = b
+        b = (b * (val + length)) // val
 
-    for index in range(length, 0, -1):
-        value = 0
-        while True:
-            tmp_idx = comb(max_value - value, index)
-            if tmp_idx <= idx:
-                idx -= tmp_idx
-                break
-            value += 1
+    for index in range(length - 1, 1, -1):
+        rank -= binomial
+        binomial = (binomial * (index + 1)) // (val + index)
+        combination[index] = val + index + offset
 
-        yield value
+        while binomial > rank:
+            val -= 1
+            binomial = (binomial * val) // (val + index)
+
+    combination[1] = val + 1 + offset
+    combination[0] = rank - binomial + offset
+
+    return combination

--- a/src/toolbox/math/combination.py
+++ b/src/toolbox/math/combination.py
@@ -54,12 +54,20 @@ def get_combination_rank(combination: Iterable[int], max_value: int = 52) -> int
     if not length:
         raise ValueError("The combination must contain values")
 
+    if length > max_value:
+        raise ValueError("The combination cannot have move values than the max value")
+
+    if length == 1:
+        return combination[0]
+
+    if length == max_value:
+        return 1
+
     rank = comb(max_value, length)
-    for idx in range(length):
-        value = combination[idx]
+    for index, value in enumerate(combination):
         if value < 1:
             raise ValueError("The combination must not contain values lower than 1")
-        rank -= comb(max_value - value, length - idx)
+        rank -= comb(max_value - value, length - index)
 
     return rank
 
@@ -110,16 +118,24 @@ def get_combination_from_rank(
     if rank > max_rank:
         raise ValueError("The rank must not be greater than the number of possible combinations")
 
+    if length == 1:
+        yield rank
+        return
+
+    if length == max_value:
+        for value in range(1, length + 1):
+            yield value
+        return
+
     idx = max_rank - rank
-    for pos in range(length, 0, -1):
-        val_idx = 0
+
+    for index in range(length, 0, -1):
         value = 0
         while True:
-            tmp_idx = comb(max_value - value, pos)
+            tmp_idx = comb(max_value - value, index)
             if tmp_idx <= idx:
-                val_idx = tmp_idx
+                idx -= tmp_idx
                 break
             value += 1
 
-        idx -= val_idx
         yield value

--- a/tests/math/test_combination.py
+++ b/tests/math/test_combination.py
@@ -2,7 +2,7 @@
 import unittest
 from typing import Iterator
 
-from toolbox.math import get_combination_from_index, get_combination_index
+from toolbox.math import get_combination_from_rank, get_combination_rank
 from toolbox.testing import test_cases
 
 
@@ -49,15 +49,15 @@ class TestCombination(unittest.TestCase):
             [[10, 11, 12], 12, 220],
         ]
     )
-    def test_get_combination_index(self, combination, max_value, index):
-        """Test get_combination_index."""
-        self.assertEqual(get_combination_index(combination, max_value), index)
+    def test_get_combination_rank(self, combination, max_value, rank):
+        """Test get_combination_rank."""
+        self.assertEqual(get_combination_rank(combination, max_value), rank)
 
-    def test_get_combination_index_error(self):
-        """Test get_combination_index errors."""
-        self.assertRaises(ValueError, get_combination_index, [1, 2], 0)
-        self.assertRaises(ValueError, get_combination_index, [], 2)
-        self.assertRaises(ValueError, get_combination_index, [0], 2)
+    def test_get_combination_rank_error(self):
+        """Test get_combination_rank errors."""
+        self.assertRaises(ValueError, get_combination_rank, [1, 2], 0)
+        self.assertRaises(ValueError, get_combination_rank, [], 2)
+        self.assertRaises(ValueError, get_combination_rank, [0], 2)
 
     @test_cases(
         [
@@ -96,15 +96,15 @@ class TestCombination(unittest.TestCase):
             [220, 3, 12, [10, 11, 12]],
         ]
     )
-    def test_get_combination_from_index(self, index, length, max_value, combination):
-        """Test get_combination_from_index."""
-        iterator = get_combination_from_index(index, length, max_value)
+    def test_get_combination_from_rank(self, rank, length, max_value, combination):
+        """Test get_combination_from_rank."""
+        iterator = get_combination_from_rank(rank, length, max_value)
         self.assertIsInstance(iterator, Iterator)
         self.assertEqual(list(iterator), combination)
 
-    def test_get_combination_from_index_error(self):
-        """Test get_combination_from_index errors."""
-        self.assertRaises(ValueError, lambda: list(get_combination_from_index(0, 2, 4)))
-        self.assertRaises(ValueError, lambda: list(get_combination_from_index(1, 0, 4)))
-        self.assertRaises(ValueError, lambda: list(get_combination_from_index(1, 2, 0)))
-        self.assertRaises(ValueError, lambda: list(get_combination_from_index(11, 2, 5)))
+    def test_get_combination_from_rank_error(self):
+        """Test get_combination_from_rank errors."""
+        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(0, 2, 4)))
+        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(1, 0, 4)))
+        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(1, 2, 0)))
+        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(11, 2, 5)))

--- a/tests/math/test_combination.py
+++ b/tests/math/test_combination.py
@@ -57,7 +57,8 @@ class TestCombination(unittest.TestCase):
         """Test get_combination_rank errors."""
         self.assertRaises(ValueError, get_combination_rank, [1, 2], 0)
         self.assertRaises(ValueError, get_combination_rank, [], 2)
-        self.assertRaises(ValueError, get_combination_rank, [0], 2)
+        self.assertRaises(ValueError, get_combination_rank, [0, 0], 5)
+        self.assertRaises(ValueError, get_combination_rank, [1, 2, 3], 2)
 
     @test_cases(
         [

--- a/tests/math/test_combination.py
+++ b/tests/math/test_combination.py
@@ -1,6 +1,5 @@
 """Test the set of functions for working with combinations."""
 import unittest
-from typing import Iterator
 
 from toolbox.math import get_combination_from_rank, get_combination_rank
 from toolbox.testing import test_cases
@@ -11,101 +10,198 @@ class TestCombination(unittest.TestCase):
 
     @test_cases(
         [
-            [[1], 5, 1],
-            [[2], 5, 2],
-            [[3], 5, 3],
-            [[4], 5, 4],
-            [[5], 5, 5],
-            [[1, 2], 5, 1],
-            [[2, 1], 5, 1],
-            [[1, 3], 5, 2],
-            [[1, 4], 5, 3],
-            [[1, 5], 5, 4],
-            [[2, 3], 5, 5],
-            [[2, 4], 5, 6],
-            [[2, 5], 5, 7],
-            [[3, 4], 5, 8],
-            [[3, 5], 5, 9],
-            [[4, 5], 5, 10],
-            [[1, 2, 3], 5, 1],
-            [[3, 2, 1], 5, 1],
-            [[1, 2, 4], 5, 2],
-            [[1, 2, 5], 5, 3],
-            [[1, 3, 4], 5, 4],
-            [[1, 3, 5], 5, 5],
-            [[1, 4, 5], 5, 6],
-            [[2, 3, 4], 5, 7],
-            [[2, 3, 5], 5, 8],
-            [[2, 4, 5], 5, 9],
-            [[3, 4, 5], 5, 10],
-            [[1, 2, 3, 4], 5, 1],
-            [[4, 2, 1, 3], 5, 1],
-            [[1, 2, 3, 5], 5, 2],
-            [[1, 2, 4, 5], 5, 3],
-            [[1, 3, 4, 5], 5, 4],
-            [[2, 3, 4, 5], 5, 5],
-            [[1, 2, 3, 4, 5], 5, 1],
-            [[11, 12], 12, 66],
-            [[10, 11, 12], 12, 220],
+            [[], 0, 0],
+            [[], 1, 0],
+            # start from 0, 5 choose 1
+            [[0], 0, 0],
+            [[1], 0, 1],
+            [[2], 0, 2],
+            [[3], 0, 3],
+            [[4], 0, 4],
+            # start from 1, 5 choose 1
+            [[1], 1, 0],
+            [[2], 1, 1],
+            [[3], 1, 2],
+            [[4], 1, 3],
+            [[5], 1, 4],
+            # start from 0, 5 choose 2
+            [[0, 1], 0, 0],
+            [[1, 0], 0, 0],
+            [[0, 2], 0, 1],
+            [[1, 2], 0, 2],
+            [[0, 3], 0, 3],
+            [[1, 3], 0, 4],
+            [[2, 3], 0, 5],
+            [[0, 4], 0, 6],
+            [[1, 4], 0, 7],
+            [[2, 4], 0, 8],
+            [[3, 4], 0, 9],
+            # start from 1, 5 choose 2
+            [[1, 2], 1, 0],
+            [[2, 1], 1, 0],
+            [[1, 3], 1, 1],
+            [[2, 3], 1, 2],
+            [[1, 4], 1, 3],
+            [[2, 4], 1, 4],
+            [[3, 4], 1, 5],
+            [[1, 5], 1, 6],
+            [[2, 5], 1, 7],
+            [[3, 5], 1, 8],
+            [[4, 5], 1, 9],
+            # start from 0, 5 choose 3
+            [[0, 1, 2], 0, 0],
+            [[2, 1, 0], 0, 0],
+            [[0, 1, 3], 0, 1],
+            [[0, 2, 3], 0, 2],
+            [[1, 2, 3], 0, 3],
+            [[0, 1, 4], 0, 4],
+            [[0, 2, 4], 0, 5],
+            [[1, 2, 4], 0, 6],
+            [[0, 3, 4], 0, 7],
+            [[1, 3, 4], 0, 8],
+            [[2, 3, 4], 0, 9],
+            # start from 1, 5 choose 3
+            [[1, 2, 3], 1, 0],
+            [[3, 1, 1], 1, 0],
+            [[1, 2, 4], 1, 1],
+            [[1, 3, 4], 1, 2],
+            [[2, 3, 4], 1, 3],
+            [[1, 2, 5], 1, 4],
+            [[1, 3, 5], 1, 5],
+            [[2, 3, 5], 1, 6],
+            [[1, 4, 5], 1, 7],
+            [[2, 4, 5], 1, 8],
+            [[3, 4, 5], 1, 9],
+            # start from 0, 5 choose 4
+            [[0, 1, 2, 3], 0, 0],
+            [[3, 1, 0, 2], 0, 0],
+            [[0, 1, 2, 4], 0, 1],
+            [[0, 1, 3, 4], 0, 2],
+            [[0, 2, 3, 4], 0, 3],
+            [[1, 2, 3, 4], 0, 4],
+            # start from 1, 5 choose 4
+            [[1, 2, 3, 4], 1, 0],
+            [[4, 2, 1, 3], 1, 0],
+            [[1, 2, 3, 5], 1, 1],
+            [[1, 2, 4, 5], 1, 2],
+            [[1, 3, 4, 5], 1, 3],
+            [[2, 3, 4, 5], 1, 4],
+            # start from 0, 5 choose 5
+            [[0, 1, 2, 3, 4], 0, 0],
+            # start from 1, 5 choose 5
+            [[1, 2, 3, 4, 5], 1, 0],
+            # start from 0, 12 choose 2
+            [[10, 11], 0, 65],
+            # start from 1, 12 choose 2
+            [[11, 12], 1, 65],
+            # start from 0, 12 choose 3
+            [[9, 10, 11], 0, 219],
+            # start from 1, 12 choose 3
+            [[10, 11, 12], 1, 219],
         ]
     )
-    def test_get_combination_rank(self, combination, max_value, rank):
+    def test_get_combination_rank(self, combination, offset, rank):
         """Test get_combination_rank."""
-        self.assertEqual(get_combination_rank(combination, max_value), rank)
+        self.assertEqual(get_combination_rank(combination, offset), rank)
 
     def test_get_combination_rank_error(self):
         """Test get_combination_rank errors."""
-        self.assertRaises(ValueError, get_combination_rank, [1, 2], 0)
-        self.assertRaises(ValueError, get_combination_rank, [], 2)
-        self.assertRaises(ValueError, get_combination_rank, [0, 0], 5)
-        self.assertRaises(ValueError, get_combination_rank, [1, 2, 3], 2)
+        self.assertRaises(ValueError, get_combination_rank, [-1])
+        self.assertRaises(ValueError, get_combination_rank, [0], 1)
+        self.assertRaises(ValueError, get_combination_rank, [-1, -1])
+        self.assertRaises(ValueError, get_combination_rank, [0, 0], 1)
 
     @test_cases(
         [
-            [1, 1, 5, [1]],
-            [2, 1, 5, [2]],
-            [3, 1, 5, [3]],
-            [4, 1, 5, [4]],
-            [5, 1, 5, [5]],
-            [1, 2, 5, [1, 2]],
-            [2, 2, 5, [1, 3]],
-            [3, 2, 5, [1, 4]],
-            [4, 2, 5, [1, 5]],
-            [5, 2, 5, [2, 3]],
-            [6, 2, 5, [2, 4]],
-            [7, 2, 5, [2, 5]],
-            [8, 2, 5, [3, 4]],
-            [9, 2, 5, [3, 5]],
-            [10, 2, 5, [4, 5]],
-            [1, 3, 5, [1, 2, 3]],
-            [2, 3, 5, [1, 2, 4]],
-            [3, 3, 5, [1, 2, 5]],
-            [4, 3, 5, [1, 3, 4]],
-            [5, 3, 5, [1, 3, 5]],
-            [6, 3, 5, [1, 4, 5]],
-            [7, 3, 5, [2, 3, 4]],
-            [8, 3, 5, [2, 3, 5]],
-            [9, 3, 5, [2, 4, 5]],
-            [10, 3, 5, [3, 4, 5]],
-            [1, 4, 5, [1, 2, 3, 4]],
-            [2, 4, 5, [1, 2, 3, 5]],
-            [3, 4, 5, [1, 2, 4, 5]],
-            [4, 4, 5, [1, 3, 4, 5]],
-            [5, 4, 5, [2, 3, 4, 5]],
-            [1, 5, 5, [1, 2, 3, 4, 5]],
-            [66, 2, 12, [11, 12]],
-            [220, 3, 12, [10, 11, 12]],
+            [0, 0, 0, []],
+            [0, 0, 1, []],
+            # start from 0, 5 choose 1
+            [0, 1, 0, [0]],
+            [1, 1, 0, [1]],
+            [2, 1, 0, [2]],
+            [3, 1, 0, [3]],
+            [4, 1, 0, [4]],
+            # start from 1, 5 choose 1
+            [0, 1, 1, [1]],
+            [1, 1, 1, [2]],
+            [2, 1, 1, [3]],
+            [3, 1, 1, [4]],
+            [4, 1, 1, [5]],
+            # start from 0, 5 choose  2
+            [0, 2, 0, [0, 1]],
+            [1, 2, 0, [0, 2]],
+            [2, 2, 0, [1, 2]],
+            [3, 2, 0, [0, 3]],
+            [4, 2, 0, [1, 3]],
+            [5, 2, 0, [2, 3]],
+            [6, 2, 0, [0, 4]],
+            [7, 2, 0, [1, 4]],
+            [8, 2, 0, [2, 4]],
+            [9, 2, 0, [3, 4]],
+            # start from 1, 5 choose 2
+            [0, 2, 1, [1, 2]],
+            [1, 2, 1, [1, 3]],
+            [2, 2, 1, [2, 3]],
+            [3, 2, 1, [1, 4]],
+            [4, 2, 1, [2, 4]],
+            [5, 2, 1, [3, 4]],
+            [6, 2, 1, [1, 5]],
+            [7, 2, 1, [2, 5]],
+            [8, 2, 1, [3, 5]],
+            [9, 2, 1, [4, 5]],
+            # start from 0, 5 choose 3
+            [0, 3, 0, [0, 1, 2]],
+            [1, 3, 0, [0, 1, 3]],
+            [2, 3, 0, [0, 2, 3]],
+            [3, 3, 0, [1, 2, 3]],
+            [4, 3, 0, [0, 1, 4]],
+            [5, 3, 0, [0, 2, 4]],
+            [6, 3, 0, [1, 2, 4]],
+            [7, 3, 0, [0, 3, 4]],
+            [8, 3, 0, [1, 3, 4]],
+            [9, 3, 0, [2, 3, 4]],
+            # start from 1, 5 choose 3
+            [0, 3, 1, [1, 2, 3]],
+            [1, 3, 1, [1, 2, 4]],
+            [2, 3, 1, [1, 3, 4]],
+            [3, 3, 1, [2, 3, 4]],
+            [4, 3, 1, [1, 2, 5]],
+            [5, 3, 1, [1, 3, 5]],
+            [6, 3, 1, [2, 3, 5]],
+            [7, 3, 1, [1, 4, 5]],
+            [8, 3, 1, [2, 4, 5]],
+            [9, 3, 1, [3, 4, 5]],
+            # start from 0, 5 choose 4
+            [0, 4, 0, [0, 1, 2, 3]],
+            [1, 4, 0, [0, 1, 2, 4]],
+            [2, 4, 0, [0, 1, 3, 4]],
+            [3, 4, 0, [0, 2, 3, 4]],
+            [4, 4, 0, [1, 2, 3, 4]],
+            # start from 1, 5 choose 4
+            [0, 4, 1, [1, 2, 3, 4]],
+            [1, 4, 1, [1, 2, 3, 5]],
+            [2, 4, 1, [1, 2, 4, 5]],
+            [3, 4, 1, [1, 3, 4, 5]],
+            [4, 4, 1, [2, 3, 4, 5]],
+            # start from 0, 5 choose 5
+            [0, 5, 0, [0, 1, 2, 3, 4]],
+            # start from 1, 5 choose 5
+            [0, 5, 1, [1, 2, 3, 4, 5]],
+            # start from 0, 12 choose  2
+            [65, 2, 0, [10, 11]],
+            # start from 1, 12 choose  2
+            [65, 2, 1, [11, 12]],
+            # start from 0, 12 choose  3
+            [219, 3, 0, [9, 10, 11]],
+            # start from 1, 12 choose  3
+            [219, 3, 1, [10, 11, 12]],
         ]
     )
-    def test_get_combination_from_rank(self, rank, length, max_value, combination):
+    def test_get_combination_from_rank(self, rank, length, offset, combination):
         """Test get_combination_from_rank."""
-        iterator = get_combination_from_rank(rank, length, max_value)
-        self.assertIsInstance(iterator, Iterator)
-        self.assertEqual(list(iterator), combination)
+        self.assertEqual(get_combination_from_rank(rank, length, offset), combination)
 
     def test_get_combination_from_rank_error(self):
         """Test get_combination_from_rank errors."""
-        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(0, 2, 4)))
-        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(1, 0, 4)))
-        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(1, 2, 0)))
-        self.assertRaises(ValueError, lambda: list(get_combination_from_rank(11, 2, 5)))
+        self.assertRaises(ValueError, lambda: get_combination_from_rank(-1, 2))
+        self.assertRaises(ValueError, lambda: get_combination_from_rank(0, -1, 4))


### PR DESCRIPTION
Rewrite the combination helpers in a more efficient way.

They now expect values starting at `0`. This will allow using the helpers with indices instead of final values.
The combinations are sorted in lexicographic order but right-to-left instead of left-to-right. This simplifies the signature as the number of possible values is no longer required.

Algorithms have been borrowed and optimized from:
- https://math.stackexchange.com/questions/1363239/fast-way-to-get-a-position-of-combination-without-repetitions
- https://math.stackexchange.com/questions/1368526/fast-way-to-get-a-combination-given-its-position-in-reverse-lexicographic-or