### PR TITLE
Feature/Add JSON options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Add options to JSONFile implementation (sort_keys, skip_keys, ensure_ascii, separators, strict).
+
 ### Fixed
 
 -   Fix the link to the documentation in the readme.

--- a/docs/toolbox.files.json_file.md
+++ b/docs/toolbox.files.json_file.md
@@ -46,15 +46,25 @@ with file:
 ---------------
 - **JSON_ENCODING**
 - **JSON_INDENT**
+- **JSON_SEPARATORS**
+- **JSON_SORT_KEYS**
+- **JSON_SKIP_KEYS**
+- **JSON_ENSURE_ASCII**
+- **JSON_STRICT**
 
 ---
 
-<a href="../src/cerbernetix/toolbox/files/json_file.py#L221"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/cerbernetix/toolbox/files/json_file.py#L264"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `read_json_file`
 
 ```python
-read_json_file(filename: str, encoding: str = 'utf-8', **kwargs) → Any
+read_json_file(
+    filename: str,
+    encoding: str = 'utf-8',
+    strict: bool = True,
+    **kwargs
+) → Any
 ```
 
 Reads a JSON content from a file. 
@@ -65,6 +75,7 @@ Reads a JSON content from a file.
  
  - <b>`filename`</b> (str):  The path to the file to read. 
  - <b>`encoding`</b> (str, optional):  The file encoding. Defaults to JSON_ENCODING. 
+ - <b>`strict`</b> (bool, optional):  Whether or not to forbid control chars. Defaults to JSON_STRICT. 
 
 
 
@@ -91,7 +102,7 @@ json_data = read_json_file('path/to/file', encoding='UTF-8')
 
 ---
 
-<a href="../src/cerbernetix/toolbox/files/json_file.py#L249"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/cerbernetix/toolbox/files/json_file.py#L294"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>function</kbd> `write_json_file`
 
@@ -101,6 +112,10 @@ write_json_file(
     data: Any,
     encoding: str = 'utf-8',
     indent: int = 4,
+    separators: tuple = None,
+    sort_keys: bool = False,
+    skip_keys: bool = False,
+    ensure_ascii: bool = True,
     **kwargs
 ) → int
 ```
@@ -115,6 +130,10 @@ Writes a JSON content to a file.
  - <b>`data`</b> (Any):  The content to write to the file. 
  - <b>`encoding`</b> (str, optional):  The file encoding. Defaults to JSON_ENCODING. 
  - <b>`indent`</b> (int, optional):  The line indent. Defaults to JSON_INDENT. 
+ - <b>`separators`</b> (tuple, optional):  The separators for key/values, a.k.a `(', ', ': ')`. Defaults to JSON_SEPARATORS. 
+ - <b>`sort_keys`</b> (bool, optional):  Whether or not to sort the keys. Defaults to JSON_SORT_KEYS. 
+ - <b>`skip_keys`</b> (bool, optional):  Whether or not to skip the keys not having an allowed type. Defaults to JSON_SKIP_KEYS. 
+ - <b>`ensure_ascii`</b> (bool, optional):  Whether or not to escape non-ascii chars. Defaults to JSON_ENSURE_ASCII. 
 
 
 
@@ -146,7 +165,7 @@ write_json_file('path/to/file', json_data, encoding='UTF-8', indent=2)
 
 ---
 
-<a href="../src/cerbernetix/toolbox/files/json_file.py#L50"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/cerbernetix/toolbox/files/json_file.py#L66"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ## <kbd>class</kbd> `JSONFile`
 Offers a simple API for reading and writing JSON files. 
@@ -163,6 +182,11 @@ The read API reads all the content at once, and so do the write API too.
  - <b>`binary`</b> (bool):  The type of file, say text. It must always be False. 
  - <b>`encoding`</b> (str, optional):  The file encoding. 
  - <b>`indent`</b> (int, optional):  The line indent. 
+ - <b>`separators`</b> (tuple, optional):  The separators for key/values, a.k.a `(', ', ': ')`. 
+ - <b>`sort_keys`</b> (bool, optional):  Whether or not to sort the keys. 
+ - <b>`skip_keys`</b> (bool, optional):  Whether or not to skip the keys not having an allowed type. 
+ - <b>`ensure_ascii`</b> (bool, optional):  Whether or not to escape non-ascii chars. 
+ - <b>`strict`</b> (bool, optional):  Whether or not to forbid control chars. 
 
 
 
@@ -187,7 +211,7 @@ with file(create=True):
 json = file.read_file()
 ``` 
 
-<a href="../src/cerbernetix/toolbox/files/json_file.py#L86"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/cerbernetix/toolbox/files/json_file.py#L107"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `__init__`
 
@@ -200,6 +224,11 @@ __init__(
     write: bool = False,
     encoding: str = 'utf-8',
     indent: int = 4,
+    separators: tuple = None,
+    sort_keys: bool = False,
+    skip_keys: bool = False,
+    ensure_ascii: bool = True,
+    strict: bool = True,
     **kwargs
 )
 ```
@@ -217,6 +246,11 @@ Creates a file manager for JSON files.
  - <b>`write`</b> (bool, optional):  Expect to also write to the file. Defaults to False. 
  - <b>`encoding`</b> (str, optional):  The file encoding. Defaults to JSON_ENCODING. 
  - <b>`indent`</b> (int, optional):  The line indent. Defaults to JSON_INDENT. 
+ - <b>`separators`</b> (tuple, optional):  The separators for key/values, a.k.a `(', ', ': ')`. Defaults to JSON_SEPARATORS. 
+ - <b>`sort_keys`</b> (bool, optional):  Whether or not to sort the keys. Defaults to JSON_SORT_KEYS. 
+ - <b>`skip_keys`</b> (bool, optional):  Whether or not to skip the keys not having an allowed type. Defaults to JSON_SKIP_KEYS. 
+ - <b>`ensure_ascii`</b> (bool, optional):  Whether or not to escape non-ascii chars. Defaults to JSON_ENSURE_ASCII. 
+ - <b>`strict`</b> (bool, optional):  Whether or not to forbid control chars. Defaults to JSON_STRICT. 
 
 
 
@@ -424,7 +458,7 @@ size = file.size
 
 ---
 
-<a href="../src/cerbernetix/toolbox/files/json_file.py#L157"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/cerbernetix/toolbox/files/json_file.py#L197"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `read`
 
@@ -464,7 +498,7 @@ with file:
 
 ---
 
-<a href="../src/cerbernetix/toolbox/files/json_file.py#L187"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+<a href="../src/cerbernetix/toolbox/files/json_file.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
 
 ### <kbd>method</kbd> `write`
 

--- a/docs/toolbox.files.md
+++ b/docs/toolbox.files.md
@@ -76,7 +76,12 @@ csv_data = file.read_zip_csv(data)
 - **CSV_DIALECT**
 - **CSV_ENCODING**
 - **JSON_ENCODING**
+- **JSON_ENSURE_ASCII**
 - **JSON_INDENT**
+- **JSON_SEPARATORS**
+- **JSON_SKIP_KEYS**
+- **JSON_SORT_KEYS**
+- **JSON_STRICT**
 
 
 

--- a/src/cerbernetix/toolbox/files/__init__.py
+++ b/src/cerbernetix/toolbox/files/__init__.py
@@ -83,6 +83,7 @@ from cerbernetix.toolbox.files.file import (
 from cerbernetix.toolbox.files.file_manager import FileManager
 from cerbernetix.toolbox.files.json_file import (
     JSON_ENCODING,
+    JSON_ENSURE_ASCII,
     JSON_INDENT,
     JSON_SKIP_KEYS,
     JSON_SORT_KEYS,

--- a/src/cerbernetix/toolbox/files/__init__.py
+++ b/src/cerbernetix/toolbox/files/__init__.py
@@ -64,6 +64,7 @@ content = file.read_zip_file(data)
 csv_data = file.read_zip_csv(data)
 ```
 """
+
 from cerbernetix.toolbox.files.csv_file import (
     CSV_DIALECT,
     CSV_ENCODING,
@@ -83,6 +84,7 @@ from cerbernetix.toolbox.files.file_manager import FileManager
 from cerbernetix.toolbox.files.json_file import (
     JSON_ENCODING,
     JSON_INDENT,
+    JSON_SORT_KEYS,
     JSONFile,
     read_json_file,
     write_json_file,

--- a/src/cerbernetix/toolbox/files/__init__.py
+++ b/src/cerbernetix/toolbox/files/__init__.py
@@ -84,6 +84,7 @@ from cerbernetix.toolbox.files.file_manager import FileManager
 from cerbernetix.toolbox.files.json_file import (
     JSON_ENCODING,
     JSON_INDENT,
+    JSON_SKIP_KEYS,
     JSON_SORT_KEYS,
     JSONFile,
     read_json_file,

--- a/src/cerbernetix/toolbox/files/__init__.py
+++ b/src/cerbernetix/toolbox/files/__init__.py
@@ -85,6 +85,7 @@ from cerbernetix.toolbox.files.json_file import (
     JSON_ENCODING,
     JSON_ENSURE_ASCII,
     JSON_INDENT,
+    JSON_SEPARATORS,
     JSON_SKIP_KEYS,
     JSON_SORT_KEYS,
     JSON_STRICT,

--- a/src/cerbernetix/toolbox/files/__init__.py
+++ b/src/cerbernetix/toolbox/files/__init__.py
@@ -87,6 +87,7 @@ from cerbernetix.toolbox.files.json_file import (
     JSON_INDENT,
     JSON_SKIP_KEYS,
     JSON_SORT_KEYS,
+    JSON_STRICT,
     JSONFile,
     read_json_file,
     write_json_file,

--- a/src/cerbernetix/toolbox/files/json_file.py
+++ b/src/cerbernetix/toolbox/files/json_file.py
@@ -53,6 +53,9 @@ JSON_SORT_KEYS = False
 # The default value for whether or not to skip the keys not having an allowed type in JSON files
 JSON_SKIP_KEYS = False
 
+# The default value for escaping non-ascii chars in JSON files
+JSON_ENSURE_ASCII = True
+
 
 class JSONFile(FileManager):
     """Offers a simple API for reading and writing JSON files.
@@ -69,6 +72,7 @@ class JSONFile(FileManager):
         indent (int, optional): The line indent.
         sort_keys (bool, optional): Whether or not to sort the keys.
         skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
+        ensure_ascii (bool, optional): Whether or not to escape non-ascii chars.
 
     Examples:
     ```python
@@ -103,6 +107,7 @@ class JSONFile(FileManager):
         indent: int = JSON_INDENT,
         sort_keys: bool = JSON_SORT_KEYS,
         skip_keys: bool = JSON_SKIP_KEYS,
+        ensure_ascii: bool = JSON_ENSURE_ASCII,
         **kwargs,
     ):
         """Creates a file manager for JSON files.
@@ -122,6 +127,8 @@ class JSONFile(FileManager):
             sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
             skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
             Defaults to JSON_SKIP_KEYS.
+            ensure_ascii (bool, optional): Whether or not to escape non-ascii chars.
+            Defaults to JSON_ENSURE_ASCII.
 
         Examples:
         ```python
@@ -169,6 +176,7 @@ class JSONFile(FileManager):
         self.indent = indent
         self.sort_keys = sort_keys
         self.skip_keys = skip_keys
+        self.ensure_ascii = ensure_ascii
 
     def read(self) -> Any:
         """Reads the content from the file.
@@ -229,6 +237,7 @@ class JSONFile(FileManager):
         return super().write(
             json.JSONEncoder(
                 skipkeys=self.skip_keys,
+                ensure_ascii=self.ensure_ascii,
                 sort_keys=self.sort_keys,
                 indent=self.indent,
             ).encode(data)
@@ -270,6 +279,7 @@ def write_json_file(
     indent: int = JSON_INDENT,
     sort_keys: bool = JSON_SORT_KEYS,
     skip_keys: bool = JSON_SKIP_KEYS,
+    ensure_ascii: bool = JSON_ENSURE_ASCII,
     **kwargs,
 ) -> int:
     """Writes a JSON content to a file.
@@ -282,6 +292,8 @@ def write_json_file(
         sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
         skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
         Defaults to JSON_SKIP_KEYS.
+        ensure_ascii (bool, optional): Whether or not to escape non-ascii chars.
+        Defaults to JSON_ENSURE_ASCII.
 
     Raises:
         OSError: If the file cannot be written.
@@ -308,5 +320,6 @@ def write_json_file(
         indent=indent,
         sort_keys=sort_keys,
         skip_keys=skip_keys,
+        ensure_ascii=ensure_ascii,
         **kwargs,
     ).write_file(data)

--- a/src/cerbernetix/toolbox/files/json_file.py
+++ b/src/cerbernetix/toolbox/files/json_file.py
@@ -35,6 +35,7 @@ with file:
     json_data = file.read()
 ```
 """
+
 import json
 from typing import Any
 
@@ -45,6 +46,9 @@ JSON_ENCODING = "utf-8"
 
 # The default indent for JSON files
 JSON_INDENT = 4
+
+# The default value for whether or not to sort the keys in JSON files
+JSON_SORT_KEYS = False
 
 
 class JSONFile(FileManager):
@@ -60,6 +64,7 @@ class JSONFile(FileManager):
         binary (bool): The type of file, say text. It must always be False.
         encoding (str, optional): The file encoding.
         indent (int, optional): The line indent.
+        sort_keys (bool, optional): Whether or not to sort the keys.
 
     Examples:
     ```python
@@ -92,6 +97,7 @@ class JSONFile(FileManager):
         write: bool = False,
         encoding: str = JSON_ENCODING,
         indent: int = JSON_INDENT,
+        sort_keys: bool = JSON_SORT_KEYS,
         **kwargs,
     ):
         """Creates a file manager for JSON files.
@@ -108,6 +114,7 @@ class JSONFile(FileManager):
             Defaults to False.
             encoding (str, optional): The file encoding. Defaults to JSON_ENCODING.
             indent (int, optional): The line indent. Defaults to JSON_INDENT.
+            sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
 
         Examples:
         ```python
@@ -153,6 +160,7 @@ class JSONFile(FileManager):
             **kwargs,
         )
         self.indent = indent
+        self.sort_keys = sort_keys
 
     def read(self) -> Any:
         """Reads the content from the file.
@@ -212,7 +220,7 @@ class JSONFile(FileManager):
         """
         return super().write(
             json.JSONEncoder(
-                sort_keys=True,
+                sort_keys=self.sort_keys,
                 indent=self.indent,
             ).encode(data)
         )
@@ -251,6 +259,7 @@ def write_json_file(
     data: Any,
     encoding: str = JSON_ENCODING,
     indent: int = JSON_INDENT,
+    sort_keys: bool = JSON_SORT_KEYS,
     **kwargs,
 ) -> int:
     """Writes a JSON content to a file.
@@ -260,6 +269,7 @@ def write_json_file(
         data (Any): The content to write to the file.
         encoding (str, optional): The file encoding. Defaults to JSON_ENCODING.
         indent (int, optional): The line indent. Defaults to JSON_INDENT.
+        sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
 
     Raises:
         OSError: If the file cannot be written.
@@ -284,5 +294,6 @@ def write_json_file(
         filename,
         encoding=encoding,
         indent=indent,
+        sort_keys=sort_keys,
         **kwargs,
     ).write_file(data)

--- a/src/cerbernetix/toolbox/files/json_file.py
+++ b/src/cerbernetix/toolbox/files/json_file.py
@@ -56,6 +56,9 @@ JSON_SKIP_KEYS = False
 # The default value for escaping non-ascii chars in JSON files
 JSON_ENSURE_ASCII = True
 
+# The default value for forbidding the control chars in JSON files
+JSON_STRICT = True
+
 
 class JSONFile(FileManager):
     """Offers a simple API for reading and writing JSON files.
@@ -73,6 +76,7 @@ class JSONFile(FileManager):
         sort_keys (bool, optional): Whether or not to sort the keys.
         skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
         ensure_ascii (bool, optional): Whether or not to escape non-ascii chars.
+        strict (bool, optional): Whether or not to forbid control chars.
 
     Examples:
     ```python
@@ -108,6 +112,7 @@ class JSONFile(FileManager):
         sort_keys: bool = JSON_SORT_KEYS,
         skip_keys: bool = JSON_SKIP_KEYS,
         ensure_ascii: bool = JSON_ENSURE_ASCII,
+        strict: bool = JSON_STRICT,
         **kwargs,
     ):
         """Creates a file manager for JSON files.
@@ -129,6 +134,8 @@ class JSONFile(FileManager):
             Defaults to JSON_SKIP_KEYS.
             ensure_ascii (bool, optional): Whether or not to escape non-ascii chars.
             Defaults to JSON_ENSURE_ASCII.
+            strict (bool, optional): Whether or not to forbid control chars.
+            Defaults to JSON_STRICT.
 
         Examples:
         ```python
@@ -177,6 +184,7 @@ class JSONFile(FileManager):
         self.sort_keys = sort_keys
         self.skip_keys = skip_keys
         self.ensure_ascii = ensure_ascii
+        self.strict = strict
 
     def read(self) -> Any:
         """Reads the content from the file.
@@ -206,7 +214,7 @@ class JSONFile(FileManager):
         if not data:
             return None
 
-        return json.JSONDecoder().decode(data)
+        return json.JSONDecoder(strict=self.strict).decode(data)
 
     def write(self, data: Any) -> int:
         """Writes content to the file.
@@ -247,6 +255,7 @@ class JSONFile(FileManager):
 def read_json_file(
     filename: str,
     encoding: str = JSON_ENCODING,
+    strict: bool = JSON_STRICT,
     **kwargs,
 ) -> Any:
     """Reads a JSON content from a file.
@@ -254,6 +263,7 @@ def read_json_file(
     Args:
         filename (str): The path to the file to read.
         encoding (str, optional): The file encoding. Defaults to JSON_ENCODING.
+        strict (bool, optional): Whether or not to forbid control chars. Defaults to JSON_STRICT.
 
     Raises:
         OSError: If the file cannot be read.
@@ -269,7 +279,7 @@ def read_json_file(
     json_data = read_json_file('path/to/file', encoding='UTF-8')
     ```
     """
-    return JSONFile(filename, encoding=encoding, **kwargs).read_file()
+    return JSONFile(filename, encoding=encoding, strict=strict, **kwargs).read_file()
 
 
 def write_json_file(

--- a/src/cerbernetix/toolbox/files/json_file.py
+++ b/src/cerbernetix/toolbox/files/json_file.py
@@ -47,6 +47,9 @@ JSON_ENCODING = "utf-8"
 # The default indent for JSON files
 JSON_INDENT = 4
 
+# The default separators for JSON files
+JSON_SEPARATORS = None
+
 # The default value for whether or not to sort the keys in JSON files
 JSON_SORT_KEYS = False
 
@@ -73,6 +76,7 @@ class JSONFile(FileManager):
         binary (bool): The type of file, say text. It must always be False.
         encoding (str, optional): The file encoding.
         indent (int, optional): The line indent.
+        separators (tuple, optional): The separators for key/values, a.k.a `(', ', ': ')`.
         sort_keys (bool, optional): Whether or not to sort the keys.
         skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
         ensure_ascii (bool, optional): Whether or not to escape non-ascii chars.
@@ -109,6 +113,7 @@ class JSONFile(FileManager):
         write: bool = False,
         encoding: str = JSON_ENCODING,
         indent: int = JSON_INDENT,
+        separators: tuple = JSON_SEPARATORS,
         sort_keys: bool = JSON_SORT_KEYS,
         skip_keys: bool = JSON_SKIP_KEYS,
         ensure_ascii: bool = JSON_ENSURE_ASCII,
@@ -129,6 +134,8 @@ class JSONFile(FileManager):
             Defaults to False.
             encoding (str, optional): The file encoding. Defaults to JSON_ENCODING.
             indent (int, optional): The line indent. Defaults to JSON_INDENT.
+            separators (tuple, optional): The separators for key/values, a.k.a `(', ', ': ')`.
+            Defaults to JSON_SEPARATORS.
             sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
             skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
             Defaults to JSON_SKIP_KEYS.
@@ -181,6 +188,7 @@ class JSONFile(FileManager):
             **kwargs,
         )
         self.indent = indent
+        self.separators = separators
         self.sort_keys = sort_keys
         self.skip_keys = skip_keys
         self.ensure_ascii = ensure_ascii
@@ -248,6 +256,7 @@ class JSONFile(FileManager):
                 ensure_ascii=self.ensure_ascii,
                 sort_keys=self.sort_keys,
                 indent=self.indent,
+                separators=self.separators,
             ).encode(data)
         )
 
@@ -287,6 +296,7 @@ def write_json_file(
     data: Any,
     encoding: str = JSON_ENCODING,
     indent: int = JSON_INDENT,
+    separators: tuple = JSON_SEPARATORS,
     sort_keys: bool = JSON_SORT_KEYS,
     skip_keys: bool = JSON_SKIP_KEYS,
     ensure_ascii: bool = JSON_ENSURE_ASCII,
@@ -299,6 +309,8 @@ def write_json_file(
         data (Any): The content to write to the file.
         encoding (str, optional): The file encoding. Defaults to JSON_ENCODING.
         indent (int, optional): The line indent. Defaults to JSON_INDENT.
+        separators (tuple, optional): The separators for key/values, a.k.a `(', ', ': ')`.
+        Defaults to JSON_SEPARATORS.
         sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
         skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
         Defaults to JSON_SKIP_KEYS.
@@ -328,6 +340,7 @@ def write_json_file(
         filename,
         encoding=encoding,
         indent=indent,
+        separators=separators,
         sort_keys=sort_keys,
         skip_keys=skip_keys,
         ensure_ascii=ensure_ascii,

--- a/src/cerbernetix/toolbox/files/json_file.py
+++ b/src/cerbernetix/toolbox/files/json_file.py
@@ -50,6 +50,9 @@ JSON_INDENT = 4
 # The default value for whether or not to sort the keys in JSON files
 JSON_SORT_KEYS = False
 
+# The default value for whether or not to skip the keys not having an allowed type in JSON files
+JSON_SKIP_KEYS = False
+
 
 class JSONFile(FileManager):
     """Offers a simple API for reading and writing JSON files.
@@ -65,6 +68,7 @@ class JSONFile(FileManager):
         encoding (str, optional): The file encoding.
         indent (int, optional): The line indent.
         sort_keys (bool, optional): Whether or not to sort the keys.
+        skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
 
     Examples:
     ```python
@@ -98,6 +102,7 @@ class JSONFile(FileManager):
         encoding: str = JSON_ENCODING,
         indent: int = JSON_INDENT,
         sort_keys: bool = JSON_SORT_KEYS,
+        skip_keys: bool = JSON_SKIP_KEYS,
         **kwargs,
     ):
         """Creates a file manager for JSON files.
@@ -115,6 +120,8 @@ class JSONFile(FileManager):
             encoding (str, optional): The file encoding. Defaults to JSON_ENCODING.
             indent (int, optional): The line indent. Defaults to JSON_INDENT.
             sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
+            skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
+            Defaults to JSON_SKIP_KEYS.
 
         Examples:
         ```python
@@ -161,6 +168,7 @@ class JSONFile(FileManager):
         )
         self.indent = indent
         self.sort_keys = sort_keys
+        self.skip_keys = skip_keys
 
     def read(self) -> Any:
         """Reads the content from the file.
@@ -220,6 +228,7 @@ class JSONFile(FileManager):
         """
         return super().write(
             json.JSONEncoder(
+                skipkeys=self.skip_keys,
                 sort_keys=self.sort_keys,
                 indent=self.indent,
             ).encode(data)
@@ -260,6 +269,7 @@ def write_json_file(
     encoding: str = JSON_ENCODING,
     indent: int = JSON_INDENT,
     sort_keys: bool = JSON_SORT_KEYS,
+    skip_keys: bool = JSON_SKIP_KEYS,
     **kwargs,
 ) -> int:
     """Writes a JSON content to a file.
@@ -270,6 +280,8 @@ def write_json_file(
         encoding (str, optional): The file encoding. Defaults to JSON_ENCODING.
         indent (int, optional): The line indent. Defaults to JSON_INDENT.
         sort_keys (bool, optional): Whether or not to sort the keys. Defaults to JSON_SORT_KEYS.
+        skip_keys (bool, optional): Whether or not to skip the keys not having an allowed type.
+        Defaults to JSON_SKIP_KEYS.
 
     Raises:
         OSError: If the file cannot be written.
@@ -295,5 +307,6 @@ def write_json_file(
         encoding=encoding,
         indent=indent,
         sort_keys=sort_keys,
+        skip_keys=skip_keys,
         **kwargs,
     ).write_file(data)

--- a/tests/files/test_json_file.py
+++ b/tests/files/test_json_file.py
@@ -9,6 +9,7 @@ from cerbernetix.toolbox.files import (
     JSON_INDENT,
     JSON_SKIP_KEYS,
     JSON_SORT_KEYS,
+    JSON_STRICT,
     JSONFile,
     read_json_file,
     write_json_file,
@@ -52,6 +53,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertEqual(file.sort_keys, JSON_SORT_KEYS)
         self.assertEqual(file.skip_keys, JSON_SKIP_KEYS)
         self.assertEqual(file.ensure_ascii, JSON_ENSURE_ASCII)
+        self.assertEqual(file.strict, JSON_STRICT)
         self.assertEqual(file.encoding, JSON_ENCODING)
         self.assertIsNone(file._file)
         self.assertEqual(file._open_args, {})
@@ -64,6 +66,7 @@ class TestJSONFile(unittest.TestCase):
         sort_keys = True
         skip_keys = True
         ensure_ascii = True
+        strict = True
         newline = "\n"
 
         file = JSONFile(
@@ -73,6 +76,7 @@ class TestJSONFile(unittest.TestCase):
             sort_keys=sort_keys,
             skip_keys=skip_keys,
             ensure_ascii=ensure_ascii,
+            strict=strict,
             newline=newline,
         )
 
@@ -82,6 +86,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertEqual(file.sort_keys, sort_keys)
         self.assertEqual(file.skip_keys, skip_keys)
         self.assertEqual(file.ensure_ascii, ensure_ascii)
+        self.assertEqual(file.strict, strict)
         self.assertEqual(file.encoding, encoding)
         self.assertIsNone(file._file)
         self.assertEqual(file._open_args, {"newline": newline})

--- a/tests/files/test_json_file.py
+++ b/tests/files/test_json_file.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from cerbernetix.toolbox.files import (
     JSON_ENCODING,
     JSON_INDENT,
+    JSON_SKIP_KEYS,
     JSON_SORT_KEYS,
     JSONFile,
     read_json_file,
@@ -48,6 +49,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertFalse(file.binary)
         self.assertEqual(file.indent, JSON_INDENT)
         self.assertEqual(file.sort_keys, JSON_SORT_KEYS)
+        self.assertEqual(file.skip_keys, JSON_SKIP_KEYS)
         self.assertEqual(file.encoding, JSON_ENCODING)
         self.assertIsNone(file._file)
         self.assertEqual(file._open_args, {})
@@ -58,6 +60,7 @@ class TestJSONFile(unittest.TestCase):
         encoding = "ascii"
         indent = 2
         sort_keys = True
+        skip_keys = True
         newline = "\n"
 
         file = JSONFile(
@@ -65,6 +68,7 @@ class TestJSONFile(unittest.TestCase):
             encoding=encoding,
             indent=indent,
             sort_keys=sort_keys,
+            skip_keys=skip_keys,
             newline=newline,
         )
 
@@ -72,6 +76,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertFalse(file.binary)
         self.assertEqual(file.indent, indent)
         self.assertEqual(file.sort_keys, sort_keys)
+        self.assertEqual(file.skip_keys, skip_keys)
         self.assertEqual(file.encoding, encoding)
         self.assertIsNone(file._file)
         self.assertEqual(file._open_args, {"newline": newline})

--- a/tests/files/test_json_file.py
+++ b/tests/files/test_json_file.py
@@ -7,6 +7,7 @@ from cerbernetix.toolbox.files import (
     JSON_ENCODING,
     JSON_ENSURE_ASCII,
     JSON_INDENT,
+    JSON_SEPARATORS,
     JSON_SKIP_KEYS,
     JSON_SORT_KEYS,
     JSON_STRICT,
@@ -25,6 +26,7 @@ JSON_STRING = """{
     ],
     "enabled": true
 }"""
+JSON_STRING_PACKED = """{"name":"test","level":20,"keywords":["one","two"],"enabled":true}"""
 JSON_STRING_SORTED = """{
     "enabled": true,
     "keywords": [
@@ -50,6 +52,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertEqual(file.filename, file_path)
         self.assertFalse(file.binary)
         self.assertEqual(file.indent, JSON_INDENT)
+        self.assertEqual(file.separators, JSON_SEPARATORS)
         self.assertEqual(file.sort_keys, JSON_SORT_KEYS)
         self.assertEqual(file.skip_keys, JSON_SKIP_KEYS)
         self.assertEqual(file.ensure_ascii, JSON_ENSURE_ASCII)
@@ -63,6 +66,7 @@ class TestJSONFile(unittest.TestCase):
         file_path = "/root/folder/file"
         encoding = "ascii"
         indent = 2
+        separators = (",", ":")
         sort_keys = True
         skip_keys = True
         ensure_ascii = True
@@ -73,6 +77,7 @@ class TestJSONFile(unittest.TestCase):
             file_path,
             encoding=encoding,
             indent=indent,
+            separators=separators,
             sort_keys=sort_keys,
             skip_keys=skip_keys,
             ensure_ascii=ensure_ascii,
@@ -83,6 +88,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertEqual(file.filename, file_path)
         self.assertFalse(file.binary)
         self.assertEqual(file.indent, indent)
+        self.assertEqual(file.separators, separators)
         self.assertEqual(file.sort_keys, sort_keys)
         self.assertEqual(file.skip_keys, skip_keys)
         self.assertEqual(file.ensure_ascii, ensure_ascii)
@@ -269,6 +275,25 @@ class TestJSONFile(unittest.TestCase):
 
         mock_file_open.assert_called_once()
         mock_file.write.assert_called_with(JSON_STRING_SORTED)
+        mock_file.close.assert_called_once()
+
+    @patch("builtins.open")
+    def test_write_file_packed(self, mock_file_open):
+        """Tests a file can be written at once."""
+        file_path = "/root/folder/file"
+
+        count = len(JSON_STRING)
+        mock_file = Mock()
+        mock_file.write = Mock(return_value=count)
+        mock_file.close = Mock()
+        mock_file_open.return_value = mock_file
+
+        file = JSONFile(file_path, indent=None, separators=(",", ":"))
+
+        self.assertEqual(file.write_file(JSON_DATA), count)
+
+        mock_file_open.assert_called_once()
+        mock_file.write.assert_called_with(JSON_STRING_PACKED)
         mock_file.close.assert_called_once()
 
     @patch("builtins.open")

--- a/tests/files/test_json_file.py
+++ b/tests/files/test_json_file.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from cerbernetix.toolbox.files import (
     JSON_ENCODING,
+    JSON_ENSURE_ASCII,
     JSON_INDENT,
     JSON_SKIP_KEYS,
     JSON_SORT_KEYS,
@@ -50,6 +51,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertEqual(file.indent, JSON_INDENT)
         self.assertEqual(file.sort_keys, JSON_SORT_KEYS)
         self.assertEqual(file.skip_keys, JSON_SKIP_KEYS)
+        self.assertEqual(file.ensure_ascii, JSON_ENSURE_ASCII)
         self.assertEqual(file.encoding, JSON_ENCODING)
         self.assertIsNone(file._file)
         self.assertEqual(file._open_args, {})
@@ -61,6 +63,7 @@ class TestJSONFile(unittest.TestCase):
         indent = 2
         sort_keys = True
         skip_keys = True
+        ensure_ascii = True
         newline = "\n"
 
         file = JSONFile(
@@ -69,6 +72,7 @@ class TestJSONFile(unittest.TestCase):
             indent=indent,
             sort_keys=sort_keys,
             skip_keys=skip_keys,
+            ensure_ascii=ensure_ascii,
             newline=newline,
         )
 
@@ -77,6 +81,7 @@ class TestJSONFile(unittest.TestCase):
         self.assertEqual(file.indent, indent)
         self.assertEqual(file.sort_keys, sort_keys)
         self.assertEqual(file.skip_keys, skip_keys)
+        self.assertEqual(file.ensure_ascii, ensure_ascii)
         self.assertEqual(file.encoding, encoding)
         self.assertIsNone(file._file)
         self.assertEqual(file._open_args, {"newline": newline})


### PR DESCRIPTION
Add options to the `JSONFile()` implementation:
- `separators (tuple, optional)`: The separators for key/values, a.k.a `(', ', ': ')`.
- `sort_keys (bool, optional)`: Whether or not to sort the keys.
- `skip_keys (bool, optional)`: Whether or not to skip the keys not having an allowed type.
- `ensure_ascii (bool, optional)`: Whether or not to escape non-ascii chars.
- `strict (bool, optional)`: Whether or not to forbid control chars.