### PR TITLE
Fix/Duration repr

### DIFF
--- a/src/cerbernetix/toolbox/time/duration.py
+++ b/src/cerbernetix/toolbox/time/duration.py
@@ -359,15 +359,7 @@ class Duration:
         Returns:
             str: The string representation of the duration.
         """
-        params = ", ".join(
-            (
-                f"{self.duration}",
-                f"precision={self.precision}",
-                f"upto={self.upto}",
-                f"style='{self.style}'",
-            )
-        )
-        return f"Duration({params})"
+        return self.to_string()
 
     def __index__(self) -> int:
         """Converts to a numeric value.

--- a/tests/time/test_duration.py
+++ b/tests/time/test_duration.py
@@ -175,14 +175,8 @@ class TestDuration(unittest.TestCase):
 
     def test_repr(self):
         """Tests a duration can be converted to string."""
-        self.assertEqual(
-            repr(Duration(1234)),
-            "Duration(1234, precision=3, upto=5, style='counter')",
-        )
-        self.assertEqual(
-            repr(Duration(1234, 4, 7, "full")),
-            "Duration(1234, precision=4, upto=7, style='full')",
-        )
+        self.assertEqual(repr(Duration(91325008063004)), "25:22:05")
+        self.assertEqual(repr(Duration(91325008063004, upto=7, style="full")), "1d 1h 22m 5s")
 
     def test_numeric(self):
         """Tests a duration can be converted to number."""


### PR DESCRIPTION
### Fixed

-    `Duration.__repr__()`: get the string representation of the duration instead of the tech details.